### PR TITLE
Prevent triggering builds on closed PRs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbRootAction.java
@@ -161,6 +161,13 @@ public class GhprbRootAction implements UnprotectedRootAction {
             } else if (StringUtils.equalsIgnoreCase("pull_request", event)) {
 
                 pr = getPullRequest(payload, gh);
+                GHIssueState state = pr.getPullRequest().getState();
+
+                if (state == GHIssueState.CLOSED) {
+                    LOGGER.log(Level.INFO, "Skip ''{0}'' event on closed PR", event);
+                    return;
+                }
+
                 repoName = pr.getRepository().getFullName();
 
                 LOGGER.log(Level.INFO, "Checking PR #{1} for {0}", new Object[] {repoName, pr.getNumber()});


### PR DESCRIPTION
Skips all kind of event triggers for closed PRs, rather than just for comments as per https://github.com/jenkinsci/ghprb-plugin/pull/54.

I've not added a test to cover this, as there's no existing test coverage for `pull_request` events in `org.jenkinsci.plugins.ghprb.GhprbRootActionTest`, nor is there any example payloads in `org.jenkinsci.plugins.ghprb.GhprbTestUtil`.

Fixes: https://github.com/jenkinsci/ghprb-plugin/issues/865